### PR TITLE
Update labs/promql/solution.md

### DIFF
--- a/labs/promql/solution.md
+++ b/labs/promql/solution.md
@@ -28,7 +28,19 @@ avg without(job, status)(rate(fulfilment_requests_total{status="failed"}[5m])) /
 ### q5- average failure rate by version:
 
 ```
-avg without(job, status, instance)(rate(fulfilment_requests_total{status="failed"}[5m]) * on(instance) group_left(app_version) app_info) / avg without(job, status, instance)(rate(fulfilment_requests_total{status="processed"}[5m])* on(instance) group_left(app_version) app_info)
+avg without (instance) (
+    (
+        avg without (job, status) (
+            rate(
+                fulfilment_requests_total{status='failed'}[5m]
+            )
+        ) / avg without (job, status) (
+            rate(
+                fulfilment_requests_total{status='processed'}[5m]
+            )
+        )
+    ) * on (instance) group_left(app_version) app_info
+)
 ```
 
 ### Results


### PR DESCRIPTION
Thank you for this amazing tutorial.
I'm a bit confused with the solution `q5 - average failure rate by version` for the problem `Build a query to show the average failure ratio over the last five minutes, split by application version`.

I’ve proposed a small fix or adjustment that might help. Perhaps you could take a look and suggest if I’m misunderstanding something?

Let me rewrite the previous query in a different way:
```
avg without(job, status, instance)(
    rate(
        fulfilment_requests_total{status="failed"}[5m]
    ) * on(instance) group_left(app_version) app_info
) / avg without(job, status, instance)(
    rate(
        fulfilment_requests_total{status="processed"}[5m]
    ) * on(instance) group_left(app_version) app_info
)
```

There we can substitute 
```
rate(
        fulfilment_requests_total{status="failed"}[5m]
    ) * on(instance) group_left(app_version) app_info
```
with `e`. As we have just 3 microservices. We end up having `<e1, e2, e3>` instant vector.

Let's substitute
```
rate(
        fulfilment_requests_total{status="processed"}[5m]
    ) * on(instance) group_left(app_version) app_info
)
```
with `p`. As we have just 3 microservices. We end up having `<p1, p2, p3>` instant vector. 

As the result we've got:
```
avg without(job, status, instance)(
  <
  {app_version="1.3.1", instance="fulfilment-processor-1:9110", job="fulfilment-processor", status="failed"} e1,
  {app_version="1.3.1", instance="fulfilment-processor-2:9110", job="fulfilment-processor", status="failed"} e2,
  {app_version="1.5.2", instance="fulfilment-processor-3:9110", job="fulfilment-processor", status="failed"} e3
  >
) / avg without(job, status, instance)(
  <
  {app_version="1.3.1", instance="fulfilment-processor-1:9110", job="fulfilment-processor", status="processed"} p1,
  {app_version="1.3.1", instance="fulfilment-processor-2:9110", job="fulfilment-processor", status="processed"} p2,
  {app_version="1.5.2", instance="fulfilment-processor-3:9110", job="fulfilment-processor", status="processed"} p3
  >
)
```
which can be rewritten as:
```
<avg(e1, e2), avg(e3)> / <avg(p1, p2), avg(p3)>
```

In mind my it feels it should be instead:
```
<avg(e1 / p1, e2 / p2>, avg(e3 / p3)>
```
So here is my proposal that is built on top of q4.